### PR TITLE
TE/ET calibration 

### DIFF
--- a/syslibrary/syslib_mflike.py
+++ b/syslibrary/syslib_mflike.py
@@ -36,8 +36,8 @@ class Calibration_alm(residual):
     from calibration factors applied to a_lm
     i.e.: a_lm^X_nu1  -> c^X_nu1 a_lm^X_nu1, with X=T,E
     cal1,cal2 are dictionaries of calibration factors c^X_nu:
-    cal1[XX][0,1,2]=[c^X_nu1,c^X_nu2,c^X_nu3]
-    cal1[XX]*cal2[YY]=G^XY
+    cal1[X][0,1,2]=[c^X_nu1,c^X_nu2,c^X_nu3]
+    cal1[X]*cal2[Y]=G^XY
     NB: cal built such that calibrated TE_nu1nu2 != TE_nu2nu1
     """
 

--- a/syslibrary/syslib_mflike.py
+++ b/syslibrary/syslib_mflike.py
@@ -47,11 +47,8 @@ class Calibration_alm(residual):
             c1=np.array(cal1[k1])[...,np.newaxis]
             for k2 in cal2.keys():
                 c2=np.array(cal2[k2])
-                if(k1==k2):
-                    cal[k1]=c1*c2
-                else:
-                    cal['te']=c1*c2
-
+                cal[k1+k2] = c1*c2
+                
         self.freq=nu
         dcl=dict()
 
@@ -59,7 +56,8 @@ class Calibration_alm(residual):
         for i1,f1 in enumerate(self.freq):
             for i2,f2 in enumerate(self.freq):
                 for spec in cal.keys():
-                    dcl[spec,f1,f2] = cal[spec][i1,i2]*self.cl[spec,f1,f2]
+                    if (spec,f1,f2) in self.cl.keys():
+                        dcl[spec,f1,f2] = cal[spec][i1,i2]*self.cl[spec,f1,f2]
 
         return dcl
 


### PR DESCRIPTION
When we do this loop in Calibration_alm.eval():

```
for k1 in cal1.keys():
    c1=np.array(cal1[k1])[...,np.newaxis]
    for k2 in cal2.keys():
        c2=np.array(cal2[k2])
        if(k1==k2):
            cal[k1]=c1*c2
        else:
            cal['te']=c1*c2
```

(with cal1 and cal2 keys being "tt", "ee" in that order !) we are correctly writing cal['te'] for k1 = "tt" (c1 = temperature cals) and k2 = "ee" (c2 = polarization cals), and for k1 = "ee" (c1 = pol cals) and k2 = "tt" (c2 = temperature cals) we are overwriting cal['te'] with cal['et'] !

We fixed this by asking now cal1 and cal2 to have keys corresponding to the signal (in a_lm or map space) that we are interested in : "t", "e", ... This requires a fix in mflike but we think that it is clearer this way. We are then filling the cal dictornary by concatenating the keys of cal1 and cal2. 
